### PR TITLE
Fix unexpected modification of parameter extra_dicts

### DIFF
--- a/zhparser.c
+++ b/zhparser.c
@@ -222,7 +222,7 @@ static void init(){
 	}
 
 	if(extra_dicts != NULL){
-	    if(!SplitIdentifierString(extra_dicts,',',&elemlist)){
+	    if(!SplitIdentifierString(pstrdup(extra_dicts),',',&elemlist)){
 		scws_free(scws);
 		list_free(elemlist);
 		scws = NULL;


### PR DESCRIPTION
SplitIdentifierString函数内部会改动传入的指针extra_dicts，因此通过pstrdup再封装一层，即不会影响到extra_dicts本身。