### PR TITLE
Fix pointer truncation crash caused by missing get_database_name declaration

### DIFF
--- a/zhparser.c
+++ b/zhparser.c
@@ -17,7 +17,11 @@
 
 #include "fmgr.h"
 #include "miscadmin.h"
+#if PG_VERSION_NUM >= 190000
+#include "utils/lsyscache.h"
+#else 
 #include "commands/dbcommands.h"
+#endif
 #include "utils/builtins.h"
 #include "utils/guc.h"
 #include "utils/memutils.h"


### PR DESCRIPTION

  PostgreSQL commit 20abdc9e82 ("Avoid including commands/dbcommands.h in
  so many places") moved the declaration of get_database_name() from
  commands/dbcommands.h to utils/lsyscache.h.  Extensions that relied on
  the old header location no longer get a proper function prototype,
  causing the compiler to assume the function returns int (32-bit) instead
  of char * (64-bit).  On x86_64 this silently truncates the returned
  pointer, leading to a segmentation fault when the truncated pointer is
  later dereferenced (e.g. by strlen inside snprintf).

  Use utils/lsyscache.h on PostgreSQL 19+ where the declaration lives
  there, and fall back to commands/dbcommands.h on older versions where it
  is still provided.

